### PR TITLE
fix: remove unused requests dependency

### DIFF
--- a/miyouqian/core/onebot.py
+++ b/miyouqian/core/onebot.py
@@ -1,4 +1,3 @@
-import requests
 from typing import Optional, Dict, Any
 from ..core.http import ApiClient
 


### PR DESCRIPTION
## Summary

- remove the stale `requests` import from the OneBot HTTP client
- keep using the existing `ApiClient`/`httpx` implementation

## Why

`miyouqian/core/onebot.py` imported `requests` even though the implementation no longer used it and the package was not declared as a dependency. This caused Docker startup to fail with `ModuleNotFoundError: No module named 'requests'`.

## Verification

- rebuilt and started the Docker Compose service
- container reached `healthy`
- `/api/auth/status` returned HTTP 200
- startup logs confirmed the Web console and exchange scheduler started normally
