### PR TITLE
🐛修复同商品多账号兑换计划互相覆盖

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ qrcode.png
 data/
 logs/
 tests/*
+!tests/test_exchange_scheduler.py

--- a/miyouqian/service/exchange_scheduler.py
+++ b/miyouqian/service/exchange_scheduler.py
@@ -109,7 +109,8 @@ class ExchangeScheduler:
                     continue
                 if exchange_at <= now:
                     continue
-                desired[attempt_key] = (index, plan, exchange_at)
+                worker_key = self._worker_key(plan, exchange_at)
+                desired[worker_key] = (index, plan, exchange_at)
 
         with self._lock:
             current_keys = set(self._workers.keys())
@@ -193,6 +194,11 @@ class ExchangeScheduler:
 
     def _attempt_key(self, plan: dict[str, Any], exchange_at: int) -> str:
         return f"{plan.get('goods_id', '')}:{exchange_at}"
+
+    def _worker_key(self, plan: dict[str, Any], exchange_at: int) -> str:
+        """生成计划线程唯一键，避免同商品同时间的多账号计划互相覆盖。"""
+        account_index = plan.get("account_index", 0)
+        return f"{account_index}:{self._attempt_key(plan, exchange_at)}"
 
 
 class PlanWorker:

--- a/tests/test_exchange_scheduler.py
+++ b/tests/test_exchange_scheduler.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+import time
+import unittest
+from unittest.mock import patch
+
+from miyouqian.service.exchange_scheduler import ExchangeScheduler, PlanWorker
+
+
+class ExchangeSchedulerWorkerKeyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.exchange_at = int(time.time()) + 3600
+
+    def make_plan(
+        self,
+        *,
+        goods_id: str,
+        account_index: int,
+        last_attempt_key: str = "",
+    ) -> dict:
+        return {
+            "goods_id": goods_id,
+            "goods_name": goods_id,
+            "account_index": account_index,
+            "exchange_at": self.exchange_at,
+            "enable": True,
+            "auto": True,
+            "last_attempt_key": last_attempt_key,
+        }
+
+    def make_scheduler(self, plans: list[dict]) -> ExchangeScheduler:
+        return ExchangeScheduler(
+            {"shop_exchange": {"enable": True, "plans": plans}},
+            lambda _index: None,
+            lambda _message: None,
+        )
+
+    @patch.object(PlanWorker, "start")
+    def test_same_goods_and_time_use_one_worker_per_account(self, start_worker) -> None:
+        plans = [
+            self.make_plan(goods_id="same-good", account_index=0),
+            self.make_plan(goods_id="same-good", account_index=1),
+        ]
+        scheduler = self.make_scheduler(plans)
+
+        scheduler.start()
+
+        self.assertEqual(scheduler.status()["worker_count"], 2)
+        self.assertEqual({worker.index for worker in scheduler._workers.values()}, {0, 1})
+        self.assertEqual(
+            set(scheduler._workers),
+            {
+                f"0:same-good:{self.exchange_at}",
+                f"1:same-good:{self.exchange_at}",
+            },
+        )
+        self.assertEqual(start_worker.call_count, 2)
+
+    @patch.object(PlanWorker, "start")
+    def test_completed_account_does_not_suppress_other_account(self, start_worker) -> None:
+        attempt_key = f"same-good:{self.exchange_at}"
+        plans = [
+            self.make_plan(
+                goods_id="same-good",
+                account_index=0,
+                last_attempt_key=attempt_key,
+            ),
+            self.make_plan(goods_id="same-good", account_index=1),
+        ]
+        scheduler = self.make_scheduler(plans)
+
+        scheduler.start()
+
+        self.assertEqual(scheduler.status()["worker_count"], 1)
+        worker = next(iter(scheduler._workers.values()))
+        self.assertEqual(worker.index, 1)
+        start_worker.assert_called_once()
+
+    def test_attempt_key_format_remains_compatible_with_saved_plans(self) -> None:
+        plan = self.make_plan(goods_id="same-good", account_index=1)
+        scheduler = self.make_scheduler([plan])
+
+        self.assertEqual(
+            scheduler._attempt_key(plan, self.exchange_at),
+            f"same-good:{self.exchange_at}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

商品兑换调度器使用`goods_id:exchange_at`作为worker唯一键。同一商品、同一兑换时间配置多个账号时，后加入的计划会覆盖前一个计划，最终只创建一个worker、只执行一个账号。

原有并发修复能够处理不同商品，但没有区分同商品下的不同账号。

## 修复

- 保留原有`last_attempt_key`格式，避免已有计划状态失效或重复执行。
- 新增包含`account_index`的worker唯一键，使同商品、同时间的每个账号都拥有独立worker。
- 补充回归测试，覆盖同商品多账号并发、单个账号已完成时不影响其他账号，以及历史执行标记格式兼容性。

## 测试

```bash
docker run --rm --entrypoint python -v /opt/MiyoQian:/workspace:ro -w /workspace docker-miyouqian -m unittest discover -s tests -v
```

结果：3项测试全部通过。

额外隔离验证中，同商品、同时间的两个账号能够生成两个独立worker：

```text
worker_count=2
worker_keys=['0:same:<timestamp>', '1:same:<timestamp>']
```

## 影响范围

仅调整商品兑换计划的worker身份，不修改兑换请求、配置格式和前端逻辑，无需迁移现有配置。
