### PR TITLE
🐛修复兑换计划重排后worker索引失效

### DIFF
--- a/miyouqian/service/exchange_scheduler.py
+++ b/miyouqian/service/exchange_scheduler.py
@@ -119,6 +119,9 @@ class ExchangeScheduler:
 
             removed_workers = [self._workers.pop(k) for k in to_remove]
             new_workers: dict[str, PlanWorker] = {}
+            for key in current_keys & desired_keys:
+                index, plan, _ = desired[key]
+                self._workers[key].update(index, plan)
             for key in to_add:
                 index, plan, exchange_at = desired[key]
                 worker = PlanWorker(index, plan, exchange_at, key, self._run_worker_plan, self.log)
@@ -220,6 +223,11 @@ class PlanWorker:
 
     def start(self) -> None:
         self._thread.start()
+
+    def update(self, index: int, plan: dict[str, Any]) -> None:
+        """同步配置重排后的计划索引与最新快照。"""
+        self.index = index
+        self.plan = plan
 
     def stop(self) -> None:
         self._stop.set()

--- a/tests/test_exchange_scheduler_reload.py
+++ b/tests/test_exchange_scheduler_reload.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+import time
+import unittest
+from unittest.mock import patch
+
+from miyouqian.service.exchange_scheduler import ExchangeScheduler, PlanWorker
+
+
+class ExchangeSchedulerReloadTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.exchange_at = int(time.time()) + 3600
+
+    def make_plan(self, goods_id: str = "target") -> dict:
+        return {
+            "goods_id": goods_id,
+            "goods_name": goods_id,
+            "account_index": 0,
+            "exchange_at": self.exchange_at,
+            "enable": True,
+            "auto": True,
+            "last_attempt_key": "",
+        }
+
+    def make_scheduler(self, plans: list[dict], run_plan_fn=lambda _index: None) -> ExchangeScheduler:
+        return ExchangeScheduler(
+            {"shop_exchange": {"enable": True, "plans": plans}},
+            run_plan_fn,
+            lambda _message: None,
+        )
+
+    @patch.object(PlanWorker, "start")
+    def test_reload_updates_retained_worker_after_plan_reorder(self, start_worker) -> None:
+        target = self.make_plan()
+        scheduler = self.make_scheduler([{}, {}, {}, {}, {}, {}, target])
+        scheduler.start()
+        worker = next(iter(scheduler._workers.values()))
+        updated_target = {**target, "goods_name": "updated-target"}
+
+        scheduler.reload({"shop_exchange": {"enable": True, "plans": [updated_target]}})
+
+        self.assertIs(next(iter(scheduler._workers.values())), worker)
+        self.assertEqual(worker.index, 0)
+        self.assertIs(worker.plan, updated_target)
+        start_worker.assert_called_once()
+
+    @patch.object(PlanWorker, "start")
+    def test_reordered_worker_runs_current_plan_index(self, _start_worker) -> None:
+        executed: list[int] = []
+        target = self.make_plan()
+        scheduler = self.make_scheduler([{}, {}, {}, {}, {}, {}, target], executed.append)
+        scheduler.start()
+        worker = next(iter(scheduler._workers.values()))
+
+        scheduler.reload({"shop_exchange": {"enable": True, "plans": [target]}})
+        worker.run_fn(worker.index)
+
+        self.assertEqual(executed, [0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

商品兑换计划线程创建时保存了计划在`shop_exchange.plans`中的数组索引。后续删除前置计划会触发调度器reload，但只要商品、账号和兑换时间构成的worker键未变化，原worker就会继续复用旧索引。

到达兑换时间后，worker按旧索引执行；如果该索引已越界，会直接报“兑换计划不存在”，没有发送兑换请求。

脱敏后的实际日志：

```text
18:05:29  新计划保存为shop_exchange.plans[6]
18:06:23  删除前置计划后，同一计划移动到shop_exchange.plans[0]
18:59:59  商品兑换计划到点触发
18:59:59  商品兑换计划7执行失败:兑换计划不存在
```

隔离复现中，修复前计划从索引`6`移动到`0`后，保留worker的索引仍为`6`。

## 修复

- reload时对继续保留的worker同步当前计划索引和最新计划快照。
- 不停止或重启等待线程，避免重复校时和不必要的调度抖动。
- 新增计划从第7项移动到第1项的回归测试，验证原worker会复用并执行最新索引`0`。

## 验证

```text
test_reload_updates_retained_worker_after_plan_reorder ... ok
test_reordered_worker_runs_current_plan_index ... ok

Ran 2 tests
OK
```

语法和模块导入检查通过。精确隔离复现结果：

```text
same_worker=true
index=0
run_index=0
```

## 已知边界

- 本PR只处理配置重排后的worker索引与计划快照同步。
- 同商品、同时间、多账号的worker键冲突由#7独立处理。
- 日志显示`18:59:59`是时间校准偏移与日志仅显示整秒共同造成，不是本次失败原因。
