### PR TITLE
对Windows Docker环境下进行兼容性修复。

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,8 @@ COPY miyouqian/ ./miyouqian/
 COPY main.py .
 COPY config.example.yaml .
 COPY docker/entrypoint.sh /entrypoint.sh
+# 对entrypoint.sh做兼容性修复，防止windows环境下因CRLF问题报错。
+RUN sed -i 's/\r$//' /entrypoint.sh
 
 RUN groupadd --system myq \
     && useradd --system --gid myq --home-dir /app --shell /usr/sbin/nologin myq \


### PR DESCRIPTION
按照教程运行的时候发现容器无法运行，报错信息为：`2026-08-20 08:50:04 miyouqian  | [FATAL tini (7)] exec /entrypoint.sh failed: No such file or directory`

排查发现原因来自于Windows 换行符 (CRLF) 问题。为了保证在windows和linux双端都能正常运行，做了一个小补丁。