### PR TITLE
fix: 修复 host 被命令行参数覆盖时外网访问也不校验密码的问题，提升外网访问密码功能安全性

### DIFF
--- a/miyouqian/cli.py
+++ b/miyouqian/cli.py
@@ -183,7 +183,7 @@ def command_show(config_path: pathlib.Path) -> int:
     print(f"凭证文件: {credentials_path(config_path, config).resolve()}")
     print(f"日志文件: {log_path(config_path, config).resolve()}")
     web = config.get("web", {})
-    print(f"Web 控制台: {web.get('host', '127.0.0.1')}:{web.get('port', 5890)}")
+    print(f"Web 控制台（配置文件中的值，启动时可被命令行参数覆盖）: {web.get('host', '127.0.0.1')}:{web.get('port', 5890)}")
     return 0
 
 

--- a/miyouqian/service/web.py
+++ b/miyouqian/service/web.py
@@ -58,9 +58,11 @@ def is_external_host(host: str) -> bool:
 
 
 class WebApp:
-    def __init__(self, config_path: pathlib.Path) -> None:
+    def __init__(self, config_path: pathlib.Path, host: str = "127.0.0.1", port: int = 5890) -> None:
         self.config_path = config_path
         self.config = load_config(config_path)
+        self.host = host
+        self.port = port
         self._ensure_password_hashed()
         self.log_file = log_path(config_path, self.config)
         configure_logger(self.log_file)
@@ -87,8 +89,11 @@ class WebApp:
 
     @property
     def need_auth(self) -> bool:
-        web = self.config.get("web", {})
-        return is_external_host(str(web.get("host", "127.0.0.1")))
+        # 为了保证不会因为命令行参数、配置文件在无意间被调整导致 Web 控制台泄露到本机之外，要求首次访问 Web 控制台时必须设置一个外网访问密码
+        stored_hash = self.config.get("web", {}).get("password", "")
+        if not stored_hash:
+            return True
+        return is_external_host(str(self.host))
 
     @property
     def password_is_set(self) -> bool:
@@ -111,12 +116,10 @@ class WebApp:
             self._sessions.pop(token, None)
 
     def auth_setup(self, password: str) -> str:
-        if not self.need_auth:
-            raise ValueError("当前为内网模式，无需设置密码")
         if self.password_is_set:
             raise ValueError("密码已设置，不能重复设置")
-        if len(password) < 4:
-            raise ValueError("密码长度至少 4 位")
+        if len(password) < 8:
+            raise ValueError("密码长度至少 8 位")
         with self.lock:
             self.config.setdefault("web", {})["password"] = hash_password(password)
             save_config(self.config_path, self.config)
@@ -1148,13 +1151,18 @@ class Handler(BaseHTTPRequestHandler):
 
 
 def serve(config_path: pathlib.Path, host: str, port: int) -> None:
-    app = WebApp(config_path)
+    app = WebApp(config_path, host, port)
     Handler.app = app
     print_startup_banner("MYQ")
     app.log(f"正在启动 Web 控制台，配置文件: {config_path.resolve()}", "startup")
-    if app.need_auth and not app.password_is_set:
-        app.log("外网模式已启用，首次访问时请设置访问密码", "auth")
+    if not app.password_is_set:
+        app.log("您尚未设置外网访问密码！首次访问 Web 控制台时请您妥善设置并保管外网访问密码！", "auth")
+    if host in ("127.0.0.1", "localhost", "::1"):
+        app.log("您设置了仅监听本机，访问 Web 控制台时将不校验外网访问密码，请您知悉。", "auth")
+    else:
+        app.log("您设置了监听外网，访问 Web 控制台时将校验外网访问密码，请您妥善设置并保管外网访问密码！", "auth")
     server, actual_port = create_server(host, port)
+    app.port = actual_port
     if actual_port != port:
         app.log(f"端口 {port} 被占用，已切换到 {actual_port}", "startup")
     app.start()

--- a/miyouqian/webui/app.js
+++ b/miyouqian/webui/app.js
@@ -3040,9 +3040,9 @@ function showAuthPage(passwordSet) {
   const shell = document.querySelector(".shell");
   shell.style.display = "none";
 
-  const subtitle = passwordSet ? "请输入访问密码" : "首次使用，请设置访问密码";
+  const subtitle = passwordSet ? "请输入访问密码" : "首次使用，请设置外网访问密码";
   const buttonText = passwordSet ? "登录" : "设置密码";
-  const inputPlaceholder = passwordSet ? "输入密码" : "设置密码（至少 4 位）";
+  const inputPlaceholder = passwordSet ? "输入密码" : "设置密码（至少 8 位）";
 
   const overlay = document.createElement("div");
   overlay.className = "auth-overlay";
@@ -3071,8 +3071,8 @@ function showAuthPage(passwordSet) {
       errorEl.textContent = "请输入密码";
       return;
     }
-    if (!passwordSet && password.length < 4) {
-      errorEl.textContent = "密码至少 4 位";
+    if (!passwordSet && password.length < 8) {
+      errorEl.textContent = "密码至少 8 位";
       return;
     }
     submitBtn.disabled = true;


### PR DESCRIPTION
目前外网访问密码功能启动时可以读取命令行中的 host 参数，但实际校验密码时只看 config 里面的 host 参数，导致命令行指定非本机地址时可以直接绕过密码校验访问控制台。

另外目前的外网访问密码只有外网第一次访问才需要设置，为了保证不会因为命令行参数、配置文件在无意间被调整导致控制台泄露到本机之外，出于安全考虑应该要求首次访问时必须设置一个密码。目前这个密码只校验八位以上且不包含超时锁定机制，其实对于互联网场景还是略有欠缺，是否考虑进一步严格建议项目作者谨慎考虑。

本 Pull Request 尝试修复了上述问题。还没来得及做详细测试，建议作者详细测试下再合并，感谢！