### PR TITLE
feat: 添加 Telegram 推送的自定义 API URL 配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,6 +911,7 @@ push:
 
 - Bot Token
 - Chat ID
+- 自定义 API URL ，可留空
 
 示例：
 
@@ -921,6 +922,7 @@ push:
       enable: true
       token: "bot token"
       chat_id: "chat id"
+      api_url: ""
 ```
 
 ### 钉钉机器人

--- a/miyouqian/core/config.py
+++ b/miyouqian/core/config.py
@@ -268,7 +268,7 @@ def normalize_cloud_game_enabled(value: Any) -> list[str]:
 PUSH_CHANNEL_FIELDS: dict[str, tuple[str, ...]] = {
     "pushplus": ("token", "topic"),
     "qq": ("push_url", "access_token", "send_id", "msg_type"),
-    "telegram": ("token", "chat_id"),
+    "telegram": ("token", "chat_id", "api_url"),
     "dingrobot": ("webhook", "secret"),
     "feishubot": ("webhook",),
     "email": ("smtp_host", "smtp_port", "smtp_user", "smtp_password", "mail_from", "mail_to", "smtp_ssl"),

--- a/miyouqian/service/notifier.py
+++ b/miyouqian/service/notifier.py
@@ -116,6 +116,8 @@ def _send_exchange(
     topic = str(push.get("topic") or "").strip()
     chat_id = str(push.get("chat_id") or "").strip()
     secret = str(push.get("secret") or "").strip()
+    # 自定义 API 地址
+    api_url = str(push.get("api_url") or "").strip()
     # QQ推送
     push_url = str(push.get("push_url") or "").strip()
     access_token = str(push.get("access_token") or "").strip()
@@ -148,7 +150,8 @@ def _send_exchange(
     if provider == "telegram":
         require(token, "token")
         require(chat_id, "chat_id")
-        url = f"https://api.telegram.org/bot{token}/sendMessage"
+        request_url = api_url or "https://api.telegram.org"
+        url = f"{request_url}/bot{token}/sendMessage"
         request_json(
             client,
             "POST",
@@ -235,6 +238,8 @@ def _send(client: httpx.Client, provider: str, push: dict[str, Any], title: str,
     topic = str(push.get("topic") or "").strip()
     chat_id = str(push.get("chat_id") or "").strip()
     secret = str(push.get("secret") or "").strip()
+    # 自定义 API 地址
+    api_url = str(push.get("api_url") or "").strip()
     # QQ推送
     push_url = str(push.get("push_url") or "").strip()
     access_token = str(push.get("access_token") or "").strip()
@@ -305,7 +310,8 @@ def _send(client: httpx.Client, provider: str, push: dict[str, Any], title: str,
     if provider == "telegram":
         require(token, "token")
         require(chat_id, "chat_id")
-        url = f"https://api.telegram.org/bot{token}/sendMessage"
+        request_url = api_url or "https://api.telegram.org"
+        url = f"{request_url}/bot{token}/sendMessage"
         request_json(
             client,
             "POST",

--- a/miyouqian/webui/app.js
+++ b/miyouqian/webui/app.js
@@ -312,6 +312,7 @@ function pushChannelFields(provider, channel) {
     webhook: channel.webhook || "",
     topic: channel.topic || "",
     chat_id: channel.chat_id || "",
+    api_url: channel.api_url || "",
     secret: channel.secret || "",
     push_url: channel.push_url || "",
     access_token: channel.access_token || "",
@@ -366,6 +367,7 @@ function pushChannelFields(provider, channel) {
     telegram: [
       field("token", "Bot Token", "password"),
       field("chat_id", "Chat ID"),
+      field("api_url", "自定义 API URL (可选)"),
     ],
     dingrobot: [
       field("webhook", "Webhook", "password"),
@@ -431,6 +433,7 @@ function hasPushChannelConfig(channel) {
     "webhook",
     "topic",
     "chat_id",
+    "api_url",
     "secret",
     "push_url",
     "access_token",
@@ -449,7 +452,7 @@ function pushChannelFieldNames(provider) {
   const fields = {
     pushplus: ["token", "topic"],
     qq: ["push_url", "access_token", "send_id", "msg_type"],
-    telegram: ["token", "chat_id"],
+    telegram: ["token", "chat_id", "api_url"],
     dingrobot: ["webhook", "secret"],
     feishubot: ["webhook"],
     email: [


### PR DESCRIPTION
Telegram Bot API 服务器的源代码已开源，开发者可以在本地运行该服务，并将请求发送到自己的服务器，而不是发送到默认服务器。具体信息详见 https://core.telegram.org/bots/api#using-a-local-bot-api-server 。

因此本 Pull Request 添加了 Telegram 自定义 API URL 配置的功能。