### PR TITLE
feat: 添加企业微信群消息推送Webhook配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,6 +960,22 @@ push:
       webhook: "https://open.feishu.cn/open-apis/bot/v2/hook/..."
 ```
 
+### 企业微信机器人
+
+需要填写：
+
+- Webhook
+
+示例：
+
+```yaml
+push:
+  channels:
+    - provider: wecombot
+      enable: true
+      webhook: "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=..."
+```
+
 ### 邮箱
 
 需要填写：

--- a/miyouqian/core/config.py
+++ b/miyouqian/core/config.py
@@ -271,11 +271,12 @@ PUSH_CHANNEL_FIELDS: dict[str, tuple[str, ...]] = {
     "telegram": ("token", "chat_id", "api_url"),
     "dingrobot": ("webhook", "secret"),
     "feishubot": ("webhook",),
+    "wecombot": ("webhook",),
     "email": ("smtp_host", "smtp_port", "smtp_user", "smtp_password", "mail_from", "mail_to", "smtp_ssl"),
 }
 
 def normalize_push_channels(push: dict[str, Any]) -> list[dict[str, Any]]:
-    allowed = {"pushplus", "telegram", "dingrobot", "feishubot", "email", "qq"}
+    allowed = {"pushplus", "telegram", "dingrobot", "feishubot", "wecombot", "email", "qq"}
     raw_channels = push.get("channels")
     if not isinstance(raw_channels, list):
         raw_channels = []

--- a/miyouqian/service/notifier.py
+++ b/miyouqian/service/notifier.py
@@ -214,6 +214,19 @@ def _send_exchange(
         request_json(client, "POST", webhook, json={"msg_type": "text", "content": {"text": "\n".join(lines)}})
         return
 
+    if provider in {"wecombot", "wecom", "企业微信"}:
+        require(webhook, "webhook")
+        request_json(
+            client,
+            "POST",
+            webhook,
+            json={
+                "msgtype": "markdown",
+                "markdown": {"content": build_exchange_markdown(title, goods_name, result, plan, success)},
+            },
+        )
+        return
+
     if provider in {"email", "smtp", "mail", "邮箱"}:
         send_mail(
             smtp_host=smtp_host,
@@ -329,6 +342,11 @@ def _send(client: httpx.Client, provider: str, push: dict[str, Any], title: str,
     if provider in {"feishubot", "feishu", "飞书"}:
         require(webhook, "webhook")
         request_json(client, "POST", webhook, json=build_feishu_post(title, message, success))
+        return
+
+    if provider in {"wecombot", "wecom", "企业微信"}:
+        require(webhook, "webhook")
+        request_json(client, "POST", webhook, json={"msgtype": "markdown", "markdown": {"content": markdown_message}})
         return
 
     if provider in {"email", "smtp", "mail", "邮箱"}:

--- a/miyouqian/webui/app.js
+++ b/miyouqian/webui/app.js
@@ -23,6 +23,7 @@ const pushChannelOptions = [
   ["telegram", "Telegram"],
   ["dingrobot", "钉钉机器人"],
   ["feishubot", "飞书机器人"],
+  ["wecombot", "企业微信机器人"],
   ["email", "邮箱"],
   ["qq", "QQ推送"]
 ];
@@ -374,6 +375,7 @@ function pushChannelFields(provider, channel) {
       field("secret", "加签 Secret", "password"),
     ],
     feishubot: [field("webhook", "Webhook", "password")],
+    wecombot: [field("webhook", "Webhook", "password")],
     email: [
       field("smtp_host", "SMTP 服务器"),
       field("smtp_port", "SMTP 端口", "number"),
@@ -455,6 +457,7 @@ function pushChannelFieldNames(provider) {
     telegram: ["token", "chat_id", "api_url"],
     dingrobot: ["webhook", "secret"],
     feishubot: ["webhook"],
+    wecombot: ["webhook"],
     email: [
       "smtp_host",
       "smtp_port",


### PR DESCRIPTION
添加企业微信群Webhook消息推送配置项，效果图如下：
<img width="1229" height="761" alt="image" src="https://github.com/user-attachments/assets/6846afeb-d5a7-44e3-b695-b90a4077bfff" />
<img width="603" height="1311" alt="98783e97834cd84acf19295bf38f98a2" src="https://github.com/user-attachments/assets/424fc4bb-3669-432c-829a-bbc690802dcd" />
